### PR TITLE
Check for IndexError

### DIFF
--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -83,10 +83,7 @@ class JoyTeleop:
     def match_command(self, c, buttons):
         """Find a command mathing a joystick configuration"""
         for b in self.command_list[c]['buttons']:
-            try:
-                if buttons[b] != 1:
-                    return False
-            except IndexError:
+            if b not in buttons or buttons[b] != 1:
                 return False
         return sum(buttons) == len(self.command_list[c]['buttons'])
 


### PR DESCRIPTION
It's happened to me on a laptop, where the trackpad has probably been detected as a joystick interface. The error becomes very annoying.
I'm not sure if this check is enough to silence it, but I think we should check that `b` isn't out of range anyway.
