### PR TITLE
Add queue_size keyword to Publisher

### DIFF
--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -64,7 +64,7 @@ class JoyTeleop:
         topic_name = command['topic_name']
         try:
             topic_type = self.get_message_type(command['message_type'])
-            self.publishers[topic_name] = rospy.Publisher(topic_name, topic_type)
+            self.publishers[topic_name] = rospy.Publisher(topic_name, topic_type, queue_size=1)
         except JoyTeleopException as e:
             rospy.logerr("could not regiter topic for command {}: {}".format(name, str(e)))
 


### PR DESCRIPTION
This solves the following issue:
```
/home/pal/reemc_indigo_ws/src/joy_teleop/scripts/joy_teleop.py:63: SyntaxWarning:
The publisher should be created with an explicit keyword argument 'queue_size'.
Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  self.publishers[topic_name] = rospy.Publisher(topic_name, topic_type)
```
as reported by @awesomebytes