### PR TITLE
Incrementer support for joint trajectory controllers

### DIFF
--- a/joy_teleop/CMakeLists.txt
+++ b/joy_teleop/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(joy_teleop)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS)
+catkin_package(
+  CATKIN_DEPENDS actionlib)
 
-catkin_package()
-
-install(PROGRAMS scripts/joy_teleop.py
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(PROGRAMS scripts/joy_teleop.py 
+                 scripts/incrementer_server.py
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/joy_teleop/package.xml
+++ b/joy_teleop/package.xml
@@ -15,5 +15,6 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rostopic</run_depend>
+  <run_depend>teleop_tools_msgs</run_depend>
 
 </package>

--- a/joy_teleop/package.xml
+++ b/joy_teleop/package.xml
@@ -4,7 +4,7 @@
   <version>0.1.2</version>
   <description>A (to be) generic joystick interface to control a robot</description>
 
-  <maintainer email="bence.magyar@pal-robotics.com">Bence Magyar</maintainer>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <author email="paul.mathieu@pal-robotics.com">Paul Mathieu</author>
 
   <license>BSD</license>

--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -1,27 +1,23 @@
 #!/usr/bin/env python
 import rospy
 import actionlib
-from control_msgs.msg import FollowJointTrajectoryAction as FJTA
-from control_msgs.msg import FollowJointTrajectoryGoal as FJTG
 import trajectory_msgs.msg as TJM
 from control_msgs.srv import QueryTrajectoryState as QTS
 import teleop_tools_msgs.msg as JTA
-
 
 class IncrementerServer:
     def __init__(self, controller_ns):
         self._as = actionlib.SimpleActionServer("increment",
             JTA.IncrementAction, execute_cb=self._as_cb, auto_start=False)
-        self._ac = actionlib.SimpleActionClient("follow_joint_trajectory", FJTA)
+        self._command_pub = rospy.Publisher("command", TJM.JointTrajectory, queue_size=2)
         #TODO add timeout
-        self._ac.wait_for_server()
         self._service_client = rospy.ServiceProxy("query_state", QTS, True)
-        #TODO add timeout
+        rospy.sleep(2.0)
         self._service_client.wait_for_service()
         result = self._service_client.call(rospy.Time.now())
         [self._value] = result.position
-        self._goal = FJTG()
-        self._goal.trajectory.joint_names = result.name
+        self._goal = TJM.JointTrajectory()
+        self._goal.joint_names = result.name
         rospy.loginfo('Connected to ' + controller_ns)
         self._as.start()
 
@@ -31,7 +27,6 @@ class IncrementerServer:
 
     def increment_by(self, increment):
         #cancel all goals sent to server
-        self._ac.cancel_all_goals()
         #TODO validate these values before sending to avoid increasing any well above the limit
         result = self._service_client.call(rospy.Time.now())
         [self._value] = result.position
@@ -40,10 +35,8 @@ class IncrementerServer:
         point = TJM.JointTrajectoryPoint()
         point.positions = [self._value]
         point.time_from_start = rospy.Duration(0.1)
-        self._goal.trajectory.header.stamp = rospy.Time.now()# + rospy.Duration(0.1)
-        self._goal.trajectory.points = [point]
-        self._ac.send_goal(self._goal)
-        self._ac.wait_for_result(rospy.Duration(0.01))
+        self._goal.points = [point]
+        self._command_pub.publish(self._goal)
 
 if __name__ == "__main__":
     rospy.init_node('incrementer_server')

--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -11,7 +11,7 @@ class IncrementerServer:
             TTIA, execute_cb=self._as_cb, auto_start=False)
         self._command_pub = rospy.Publisher("command", JointTrajectory, queue_size=1)
         state = rospy.wait_for_message("state", JTCS)
-        [self._value] = state.actual.positions
+        self._value = state.actual.positions
         self._goal = JointTrajectory()
         self._goal.joint_names = state.joint_names
         rospy.loginfo('Connected to ' + controller_ns)
@@ -23,11 +23,11 @@ class IncrementerServer:
 
     def increment_by(self, increment):
         state = rospy.wait_for_message("state", JTCS)
-        [self._value] = state.actual.positions
-        self._value += increment
+        self._value = state.actual.positions
+        self._value = [x + y for x, y in zip(self._value, increment)]
         rospy.loginfo('Sent goal of ' + str(self._value))
         point = JointTrajectoryPoint()
-        point.positions = [self._value]
+        point.positions = self._value
         point.time_from_start = rospy.Duration(0.1)
         self._goal.points = [point]
         self._command_pub.publish(self._goal)

--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -10,12 +10,12 @@ import teleop_tools_msgs.msg as JTA
 
 class IncrementerServer:
     def __init__(self, controller_ns):
-        self._as = actionlib.SimpleActionServer(controller_ns + "/increment",
+        self._as = actionlib.SimpleActionServer("increment",
             JTA.IncrementAction, execute_cb=self._as_cb, auto_start=False)
-        self._ac = actionlib.SimpleActionClient(controller_ns + "/follow_joint_trajectory", FJTA)
+        self._ac = actionlib.SimpleActionClient("follow_joint_trajectory", FJTA)
         #TODO add timeout
         self._ac.wait_for_server()
-        self._service_client = rospy.ServiceProxy(controller_ns + "/query_state", QTS, True)
+        self._service_client = rospy.ServiceProxy("query_state", QTS, True)
         #TODO add timeout
         self._service_client.wait_for_service()
         result = self._service_client.call(rospy.Time.now())

--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python
 import rospy
 import actionlib
-import trajectory_msgs.msg as TJM
-from control_msgs.srv import QueryTrajectoryState as QTS
-import teleop_tools_msgs.msg as JTA
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+from control_msgs.msg import JointTrajectoryControllerState as JTCS
+from teleop_tools_msgs.msg import IncrementAction as TTIA
 
 class IncrementerServer:
     def __init__(self, controller_ns):
         self._as = actionlib.SimpleActionServer("increment",
-            JTA.IncrementAction, execute_cb=self._as_cb, auto_start=False)
-        self._command_pub = rospy.Publisher("command", TJM.JointTrajectory, queue_size=2)
-        #TODO add timeout
-        self._service_client = rospy.ServiceProxy("query_state", QTS, True)
-        rospy.sleep(2.0)
-        self._service_client.wait_for_service()
-        result = self._service_client.call(rospy.Time.now())
-        [self._value] = result.position
-        self._goal = TJM.JointTrajectory()
-        self._goal.joint_names = result.name
+            TTIA, execute_cb=self._as_cb, auto_start=False)
+        self._command_pub = rospy.Publisher("command", JointTrajectory, queue_size=1)
+        state = rospy.wait_for_message("state", JTCS)
+        [self._value] = state.actual.positions
+        self._goal = JointTrajectory()
+        self._goal.joint_names = state.joint_names
         rospy.loginfo('Connected to ' + controller_ns)
         self._as.start()
 
@@ -26,13 +22,11 @@ class IncrementerServer:
         self._as.set_succeeded([])
 
     def increment_by(self, increment):
-        #cancel all goals sent to server
-        #TODO validate these values before sending to avoid increasing any well above the limit
-        result = self._service_client.call(rospy.Time.now())
-        [self._value] = result.position
+        state = rospy.wait_for_message("state", JTCS)
+        [self._value] = state.actual.positions
         self._value += increment
         rospy.loginfo('Sent goal of ' + str(self._value))
-        point = TJM.JointTrajectoryPoint()
+        point = JointTrajectoryPoint()
         point.positions = [self._value]
         point.time_from_start = rospy.Duration(0.1)
         self._goal.points = [point]

--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -23,7 +23,7 @@ class IncrementerServer:
 
     def increment_by(self, increment):
         state = rospy.wait_for_message("state", JTCS)
-        self._value = state.actual.positions
+        self._value = state.desired.positions
         self._value = [x + y for x, y in zip(self._value, increment)]
         rospy.loginfo('Sent goal of ' + str(self._value))
         point = JointTrajectoryPoint()

--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+import rospy
+import actionlib
+from control_msgs.msg import FollowJointTrajectoryAction as FJTA
+from control_msgs.msg import FollowJointTrajectoryGoal as FJTG
+import trajectory_msgs.msg as TJM
+from control_msgs.srv import QueryTrajectoryState as QTS
+import teleop_tools_msgs.msg as JTA
+
+
+class IncrementerServer:
+    def __init__(self, controller_ns):
+        self._as = actionlib.SimpleActionServer(controller_ns + "/increment",
+            JTA.IncrementAction, execute_cb=self._as_cb, auto_start=False)
+        self._ac = actionlib.SimpleActionClient(controller_ns + "/follow_joint_trajectory", FJTA)
+        #TODO add timeout
+        self._ac.wait_for_server()
+        self._service_client = rospy.ServiceProxy(controller_ns + "/query_state", QTS, True)
+        #TODO add timeout
+        self._service_client.wait_for_service()
+        result = self._service_client.call(rospy.Time.now())
+        [self._value] = result.position
+        self._goal = FJTG()
+        self._goal.trajectory.joint_names = result.name
+        rospy.loginfo('Connected to ' + controller_ns)
+        self._as.start()
+
+    def _as_cb(self, goal):
+        self.increment_by(goal.increment_by)
+        self._as.set_succeeded([])
+
+    def increment_by(self, increment):
+        #cancel all goals sent to server
+        self._ac.cancel_all_goals()
+        #TODO validate these values before sending to avoid increasing any well above the limit
+        result = self._service_client.call(rospy.Time.now())
+        [self._value] = result.position
+        self._value += increment
+        rospy.loginfo('Sent goal of ' + str(self._value))
+        point = TJM.JointTrajectoryPoint()
+        point.positions = [self._value]
+        point.time_from_start = rospy.Duration(0.1)
+        self._goal.trajectory.header.stamp = rospy.Time.now()# + rospy.Duration(0.1)
+        self._goal.trajectory.points = [point]
+        self._ac.send_goal(self._goal)
+        self._ac.wait_for_result(rospy.Duration(0.01))
+
+if __name__ == "__main__":
+    rospy.init_node('incrementer_server')
+    controller_namespace = 'spine_controller'
+    server = IncrementerServer(controller_namespace)
+    rospy.spin()

--- a/key_teleop/package.xml
+++ b/key_teleop/package.xml
@@ -4,7 +4,7 @@
   <version>0.1.2</version>
   <description>A text-based interface to send a robot movement commands</description>
 
-  <maintainer email="bence.magyar@pal-robotics.com">Bence Magyar</maintainer>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <author email="siegfried.gevatter@pal-robotics.com">Siegfried-A. Gevatter Pujals</author>
 
   <license>BSD</license>

--- a/teleop_tools/package.xml
+++ b/teleop_tools/package.xml
@@ -3,13 +3,14 @@
   <name>teleop_tools</name>
   <version>0.1.2</version>
   <description>A set of generic teleoperation tools for any robot.</description>
-  <maintainer email="bence.magyar@pal-robotics.com">Bence Magyar</maintainer>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>joy_teleop</run_depend>
   <run_depend>key_teleop</run_depend>
+  <run_depend>teleop_tools_msgs</run_depend>
 
   <export>
     <metapackage/>

--- a/teleop_tools_msgs/CMakeLists.txt
+++ b/teleop_tools_msgs/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(teleop_tools_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+  actionlib_msgs
+  control_msgs
+  message_generation)
+
+add_action_files(DIRECTORY action FILES Increment.action)
+generate_messages(DEPENDENCIES actionlib_msgs)
+
+catkin_package(
+  CATKIN_DEPENDS message_runtime 
+                 rospy actionlib_msgs
+)
+

--- a/teleop_tools_msgs/action/Increment.action
+++ b/teleop_tools_msgs/action/Increment.action
@@ -1,0 +1,3 @@
+float32 increment_by
+---
+---

--- a/teleop_tools_msgs/action/Increment.action
+++ b/teleop_tools_msgs/action/Increment.action
@@ -1,3 +1,3 @@
-float32 increment_by
+float32[] increment_by
 ---
 ---

--- a/teleop_tools_msgs/package.xml
+++ b/teleop_tools_msgs/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+  <name>teleop_tools_msgs</name>
+  <version>0.0.0</version>
+  <description>The teleop_tools_msgs package</description>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>control_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>rospy</build_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>control_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>rospy</run_depend>
+</package>

--- a/teleop_tools_msgs/package.xml
+++ b/teleop_tools_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>teleop_tools_msgs</name>
-  <version>0.0.0</version>
+  <version>0.1.2</version>
   <description>The teleop_tools_msgs package</description>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
This patch adds support for joint trajectory controllers to be used in an incementing fashion. 
Joystick buttons can be configured to be increment/decrement the position value of a configured joint. For the rest of the joints of that controller the current desired goal is kept.

Example of robot using this: http://wiki.ros.org/Robots/TIAGo
Left lower & upper trigger: column down / up
Buttons on the right pad: head up/down/left/right