### PR TITLE
Fix incrementer server sending out of possible range goals

### DIFF
--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -23,7 +23,7 @@ class IncrementerServer:
 
     def increment_by(self, increment):
         state = rospy.wait_for_message("state", JTCS)
-        self._value = state.desired.positions
+        self._value = state.actual.positions
         self._value = [x + y for x, y in zip(self._value, increment)]
         rospy.loginfo('Sent goal of ' + str(self._value))
         point = JointTrajectoryPoint()

--- a/joy_teleop/scripts/incrementer_server.py
+++ b/joy_teleop/scripts/incrementer_server.py
@@ -5,11 +5,16 @@ from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 from control_msgs.msg import JointTrajectoryControllerState as JTCS
 from teleop_tools_msgs.msg import IncrementAction as TTIA
 
+
 class IncrementerServer:
     def __init__(self, controller_ns):
         self._as = actionlib.SimpleActionServer("increment",
-            TTIA, execute_cb=self._as_cb, auto_start=False)
-        self._command_pub = rospy.Publisher("command", JointTrajectory, queue_size=1)
+                                                TTIA,
+                                                execute_cb=self._as_cb,
+                                                auto_start=False)
+        self._command_pub = rospy.Publisher("command",
+                                            JointTrajectory,
+                                            queue_size=1)
         state = rospy.wait_for_message("state", JTCS)
         self._value = state.actual.positions
         self._goal = JointTrajectory()


### PR DESCRIPTION
Dear well respected sirs, I hope this PR is of your delight.

When repeatedly sending incrementer goals the goal would grow infinitely so you would need to send the same amount of decrementing goals to get able to recover control (or the other way around too).

Also (auto)fixing style in a separate commit.
