### PR TITLE
More pressed buttons should not cancel deadman button

### DIFF
--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -135,7 +135,7 @@ class JoyTeleop:
         for b in self.command_list[c]['buttons']:
             if b < 0 or len(buttons) <= b or buttons[b] != 1:
                 return False
-        return sum(buttons) == len(self.command_list[c]['buttons'])
+        return sum(buttons) >= len(self.command_list[c]['buttons'])
 
     def add_command(self, name, command):
         """Add a command to the command list"""


### PR DESCRIPTION
During teleop we have additional actions we want to perform with other buttons. For example and override or an action pressed with our other hand.

Now the teleop (which has a deadman button) is cancelled because more buttons are pressed.

This pull requests supports additional buttons to be pressed next to the deadman button.

Example config:

```yaml
teleop:
  xbox_cmd_vel:
    type: topic
    message_type: "geometry_msgs/Twist"
    topic_name: cmd_vel
    deadman_buttons: [5]   #RB
    axis_mappings:
      -
        axis: 4  # Right thumb stick (up/down)
        target: linear.x
        scale: 1.0
        offset: 0.0
      -
        axis: 0  # Left thumb stick (left/right)
        target: angular.z
        scale: 1.0
        offset: 0.0

  safety_override:
    type: topic
    message_type: "std_msgs/Empty"
    topic_name: override
    deadman_buttons: [5, 3]  # RB + Y
    axis_mappings: []
```