### PR TITLE
Persistent service optionnal 

### DIFF
--- a/joy_teleop/config/joy_teleop_example.yaml
+++ b/joy_teleop/config/joy_teleop_example.yaml
@@ -104,3 +104,12 @@ teleop:
         value:
           - 4
           - 2
+
+  add_two_ints:
+    type: service
+    service_name: /add_two_ints
+    service_request:
+      a: 11
+      b: 31
+    service_persistent: False # False by default
+    buttons: [10]

--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -91,7 +91,7 @@ class JoyTeleop:
                 self.offline_actions.append(action_name)
 
     class AsyncServiceProxy(object):
-        def __init__(self, name, service_class, persistent=True):
+        def __init__(self, name, service_class, persistent):
             try:
                 rospy.wait_for_service(name, timeout=2.0)
             except ROSException:
@@ -118,11 +118,15 @@ class JoyTeleop:
     def register_service(self, name, command):
         """ Add an AsyncServiceProxy for a joystick command """
         service_name = command['service_name']
+        if 'service_persistent' not in command:
+            command['service_persistent'] = False
+        service_persistent = command['service_persistent']
         try:
             service_type = self.get_service_type(service_name)
             self.srv_clients[service_name] = self.AsyncServiceProxy(
                 service_name,
-                service_type)
+                service_type,
+                service_persistent)
 
             if service_name in self.offline_services:
                 self.offline_services.remove(service_name)


### PR DESCRIPTION
Add `service_persistent` parameter to be passed to `rospy.ServiceProxy` and default it to `False`.

Add also a small dummy service example.