### PR TITLE
Fill in the timestamp of outgoing messages, if applicable.

### DIFF
--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -210,6 +210,10 @@ class JoyTeleop:
 
                 self.set_member(msg, mapping['target'], val)
 
+        # If there is a stamp field, fill it with rospy.Time.now()
+        if hasattr(msg, 'header'):
+            msg.header.stamp = rospy.Time.now()
+
         self.publishers[cmd['topic_name']].publish(msg)
 
     def run_action(self, c, joy_state):


### PR DESCRIPTION
This is related to https://github.com/ros-planning/moveit/pull/1244

It  would be nice to have a timestamp so I can check for stale commands.