### PR TITLE
Log JoyTeleopException

### DIFF
--- a/joy_teleop/joy_teleop/joy_teleop.py
+++ b/joy_teleop/joy_teleop/joy_teleop.py
@@ -317,20 +317,19 @@ class JoyTeleop(Node):
                 self.register_action(name, cmd)
 
 
-def main():
+def main(args=None):
+    rclpy.init(args=args)
+    node = JoyTeleop()
+
     try:
-        rclpy.init()
-
-        node = JoyTeleop()
-
         rclpy.spin(node)
-
-        node.destroy_node()
-        rclpy.shutdown()
-    except JoyTeleopException:
-        pass
+    except JoyTeleopException as e:
+        node.get_logger().error(e.message)
     except KeyboardInterrupt:
         pass
+
+    node.destroy_node()
+    rclpy.shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Current `joy_teleop.py` implementation passes JoyTeleopException without any logging.
It might be difficult to debug `config.yaml` description.

This PR improves it.