### PR TITLE
Add the ability to have deadman axes.

### DIFF
--- a/joy_teleop/joy_teleop/joy_teleop.py
+++ b/joy_teleop/joy_teleop/joy_teleop.py
@@ -179,14 +179,14 @@ class JoyTeleop(Node):
 
     def match_button_command(self, c, buttons):
         """Find a command matching a joystick configuration."""
-        if len(buttons) == 0 or len(self.command_list[c]['buttons']) == 0 or \
+        if len(buttons) == 0 or not 'buttons' in self.command_list[c] or len(self.command_list[c]['buttons']) == 0 or \
            len(buttons) <= max(self.command_list[c]['buttons']):
             return False
         return any(buttons[cmd_button] for cmd_button in self.command_list[c]['buttons'])
 
     def match_axis_command(self, c, axes):
         """Find a command matching a joystick configuration."""
-        if len(axes) == 0 or len(self.command_list[c]['axes']) == 0 or \
+        if len(axes) == 0 or not 'axes' in self.command_list[c] or len(self.command_list[c]['axes']) == 0 or \
            len(axes) <= max(int(cmd_axis) for cmd_axis, value in self.command_list[c]['axes'].items()):
             return False
 


### PR DESCRIPTION
Some controllers don't have a convenient shoulder trigger
button, but do have shoulder "axes".  Allow the axes to
be used for a deadman trigger, assuming they are pressed
all the way.  Note that I used a dict for the list of
axes, as this provides the most convenient way to deal
with controllers that use 1.0, -1.0, or 0.0 as the "far"
end of the axis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>