### PR TITLE
Fix missing mouse_teleop installed dir

### DIFF
--- a/teleop_tools/package.xml
+++ b/teleop_tools/package.xml
@@ -10,6 +10,7 @@
 
   <run_depend>joy_teleop</run_depend>
   <run_depend>key_teleop</run_depend>
+  <run_depend>mouse_teleop</run_depend>
   <run_depend>teleop_tools_msgs</run_depend>
 
   <export>


### PR DESCRIPTION
Thank you for nice package.
I found the "mouse_teleop" dir is not installed on /opt/ros/melodic/share/ with apt install process.
(Sorry, I just confirmed with melodic, not tested with kinetic yet)

With source compiling, I could use mouse_teleop feature.
So this PR could be the correct way.