### PR TITLE
Noetic updates

### DIFF
--- a/joy_teleop/CMakeLists.txt
+++ b/joy_teleop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(joy_teleop)
 
 find_package(catkin REQUIRED COMPONENTS)

--- a/joy_teleop/CMakeLists.txt
+++ b/joy_teleop/CMakeLists.txt
@@ -5,9 +5,9 @@ find_package(catkin REQUIRED COMPONENTS)
 catkin_package(
   CATKIN_DEPENDS actionlib)
 
-install(PROGRAMS scripts/joy_teleop.py 
-                 scripts/incrementer_server.py
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS scripts/joy_teleop.py
+                               scripts/incrementer_server.py
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 foreach(dir config launch)
     install(DIRECTORY ${dir}/

--- a/key_teleop/CMakeLists.txt
+++ b/key_teleop/CMakeLists.txt
@@ -5,5 +5,5 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-install(PROGRAMS scripts/key_teleop.py
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS scripts/key_teleop.py
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/key_teleop/CMakeLists.txt
+++ b/key_teleop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(key_teleop)
 
 find_package(catkin REQUIRED)

--- a/key_teleop/scripts/key_teleop.py
+++ b/key_teleop/scripts/key_teleop.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2013 PAL Robotics SL.

--- a/mouse_teleop/CMakeLists.txt
+++ b/mouse_teleop/CMakeLists.txt
@@ -5,8 +5,8 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-install(PROGRAMS scripts/mouse_teleop.py
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS scripts/mouse_teleop.py
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 foreach(dir config launch)
   install(DIRECTORY ${dir}/

--- a/mouse_teleop/CMakeLists.txt
+++ b/mouse_teleop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mouse_teleop)
 
 find_package(catkin REQUIRED)

--- a/mouse_teleop/scripts/mouse_teleop.py
+++ b/mouse_teleop/scripts/mouse_teleop.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2015 Enrique Fernandez

--- a/teleop_tools/CMakeLists.txt
+++ b/teleop_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(teleop_tools)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/teleop_tools_msgs/CMakeLists.txt
+++ b/teleop_tools_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(teleop_tools_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -10,7 +10,7 @@ add_action_files(DIRECTORY action FILES Increment.action)
 generate_messages(DEPENDENCIES actionlib_msgs)
 
 catkin_package(
-  CATKIN_DEPENDS message_runtime 
+  CATKIN_DEPENDS message_runtime
                  actionlib_msgs
 )
 


### PR DESCRIPTION
Tested locally but it doesn't seem to be enough yet.

* [ ] Joy teleop failure: 
```
Traceback (most recent call last):
  File "/ws/install/lib/joy_teleop/joy_teleop.py", line 2, in <module>
    from future.utils import iteritems
ModuleNotFoundError: No module named 'future'
```
* [ ] mouse teleop misses python3-tk in package.xml (rosdep equivalent flag wrong?)
* [ ] mouse teleop failure:
```
Traceback (most recent call last):
  File "/ws/install/lib/mouse_teleop/mouse_teleop.py", line 242, in <module>
    main()
  File "/ws/install/lib/mouse_teleop/mouse_teleop.py", line 238, in main
    MouseTeleop()
  File "/ws/install/lib/mouse_teleop/mouse_teleop.py", line 43, in __init__
    self._root = tkinter.Tk()
  File "/usr/lib/python3.8/tkinter/__init__.py", line 2261, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
_tkinter.TclError: no display name and no $DISPLAY environment variable
Exception ignored in: <function MouseTeleop.__del__ at 0x7f281397e790>
Traceback (most recent call last):
  File "/ws/install/lib/mouse_teleop/mouse_teleop.py", line 118, in __del__
    self._timer.shutdown()
AttributeError: 'MouseTeleop' object has no attribute '_timer'
```