### PR TITLE
Possibility to use TwistStamped (still Twist by default)

### DIFF
--- a/key_teleop/key_teleop/key_teleop.py
+++ b/key_teleop/key_teleop/key_teleop.py
@@ -127,9 +127,9 @@ class SimpleKeyTeleop(Node):
 
         self._interface = interface
 
-        self._twist_stamp_enabled = self.declare_parameter('twist_stamped_enabled', False).value
+        self._publish_stamped_twist = self.declare_parameter('twist_stamped_enabled', False).value
 
-        if self._twist_stamp_enabled:
+        if self._publish_stamped_twist:
             self._pub_cmd = self.create_publisher(TwistStamped, 'key_vel', qos_profile_system_default)
         else:
             self._pub_cmd = self.create_publisher(Twist, 'key_vel', qos_profile_system_default)
@@ -169,7 +169,7 @@ class SimpleKeyTeleop(Node):
         twist.angular.z = angular
         return twist
 
-    def _get_twist_stamped(self, linear, angular):
+    def _make_twist_stamped(self, linear, angular):
         twist_stamped = TwistStamped()
         header = Header()
         header.stamp = rclpy.clock.Clock().now().to_msg()
@@ -214,8 +214,8 @@ class SimpleKeyTeleop(Node):
         self._interface.write_line(5, 'Use arrow keys to move, q to exit.')
         self._interface.refresh()
 
-        if self._twist_stamp_enabled:
-            twist = self._get_twist_stamped(self._linear, self._angular)
+        if self._publish_stamped_twist:
+            twist = self._make_twist_stamped(self._linear, self._angular)
         else:
             twist = self._get_twist(self._linear, self._angular)
 

--- a/key_teleop/key_teleop/key_teleop.py
+++ b/key_teleop/key_teleop/key_teleop.py
@@ -163,7 +163,7 @@ class SimpleKeyTeleop(Node):
             # TODO(artivis) use Rate once available
             time.sleep(1.0/self._hz)
 
-    def _get_twist(self, linear, angular):
+    def _make_twist(self, linear, angular):
         twist = Twist()
         twist.linear.x = linear
         twist.angular.z = angular
@@ -217,7 +217,7 @@ class SimpleKeyTeleop(Node):
         if self._publish_stamped_twist:
             twist = self._make_twist_stamped(self._linear, self._angular)
         else:
-            twist = self._get_twist(self._linear, self._angular)
+            twist = self._make_twist(self._linear, self._angular)
 
         self._pub_cmd.publish(twist)
 


### PR DESCRIPTION
Ros2_control decided to go for TwistStamped (which I can understand because of the extra info + timestamp you get) however that makes it incompatible with this library. This is a suggested fix for that, if you feel this is an option, i'll go ahead and change the other modules (joy and  mouse) the same way.

Let me know what you think :) 

PS. would be good to create a foxy-devel branch as well.
