### PR TITLE
Allow a `value` type within an axis mapping. Useful for frame data.

### DIFF
--- a/joy_teleop/config/joy_teleop_example.yaml
+++ b/joy_teleop/config/joy_teleop_example.yaml
@@ -3,7 +3,7 @@ joy_teleop:
 
     walk:
       type: topic
-      interface_type: geometry_msgs/msg/Twist
+      interface_type: geometry_msgs/msg/TwistStamped
       topic_name: cmd_vel
       deadman_buttons: [4]
       axis_mappings:
@@ -20,6 +20,8 @@ joy_teleop:
         linear-z:
           button: 2
           scale: 3.0
+        header-frame_id:
+          value: 'my_tf_frame'
 
     force_push:
       type: topic

--- a/joy_teleop/joy_teleop/joy_teleop.py
+++ b/joy_teleop/joy_teleop/joy_teleop.py
@@ -154,16 +154,18 @@ class JoyTeleopTopicCommand(JoyTeleopCommand):
             self.axis_mappings = config['axis_mappings']
             # Now check that the mappings have all of the required configuration.
             for mapping, values in self.axis_mappings.items():
-                if 'axis' not in values and 'button' not in values:
-                    raise JoyTeleopException("Axis mapping for '{}' must have an axis or button"
-                                             .format(name))
-                if 'offset' not in values:
-                    raise JoyTeleopException("Axis mapping for '{}' must have an offset"
+                if 'axis' not in values and 'button' not in values and 'value' not in values:
+                    raise JoyTeleopException("Axis mapping for '{}' must have an axis, button, or value"
                                              .format(name))
 
-                if 'scale' not in values:
-                    raise JoyTeleopException("Axis mapping for '{}' must have a scale"
-                                             .format(name))
+                if 'axis' in values:
+                    if 'offset' not in values:
+                        raise JoyTeleopException("Axis mapping for '{}' must have an offset"
+                                                 .format(name))
+
+                    if 'scale' not in values:
+                        raise JoyTeleopException("Axis mapping for '{}' must have a scale"
+                                                 .format(name))
 
         if self.msg_value is None and not self.axis_mappings:
             raise JoyTeleopException("No 'message_value' or 'axis_mappings' "
@@ -223,6 +225,9 @@ class JoyTeleopTopicCommand(JoyTeleopCommand):
                                                 'but #{} was referenced in config.'.format(
                                                     len(joy_state.buttons), values['button']))
                         val = 0.0
+                elif 'value' in values:
+                    # Pass on the value as its Python-implicit type
+                    val = values.get('value')
                 else:
                     node.get_logger().error(
                         'No Supported axis_mappings type found in: {}'.format(mapping))


### PR DESCRIPTION
See the example in joy_teleop_example.yaml. I hope it is self-explanatory.