### PR TITLE
launch: fix deprecated attributes

### DIFF
--- a/joy_teleop/launch/example.launch.py
+++ b/joy_teleop/launch/example.launch.py
@@ -37,11 +37,11 @@ def generate_launch_description():
     ])
 
     ld.add_action(launch_ros.actions.Node(
-            package='joy_teleop', node_executable='joy_teleop',
+            package='joy_teleop', executable='joy_teleop',
             parameters=[launch.substitutions.LaunchConfiguration('teleop_config')]))
 
     ld.add_action(launch_ros.actions.Node(
-            package='joy_teleop', node_executable='incrementer_server',
-            node_name='incrementer', node_namespace='torso_controller'))
+            package='joy_teleop', executable='incrementer_server',
+            name='incrementer', namespace='torso_controller'))
 
     return ld

--- a/mouse_teleop/launch/mouse_teleop.launch.py
+++ b/mouse_teleop/launch/mouse_teleop.launch.py
@@ -27,7 +27,7 @@ def generate_launch_description():
     )
 
     mouse_teleop = launch_ros.actions.Node(
-            package='mouse_teleop', node_executable='mouse_teleop',
+            package='mouse_teleop', executable='mouse_teleop',
             parameters=[parameters_file])
 
     return LaunchDescription([mouse_teleop])


### PR DESCRIPTION
Hi,

This fixes the example launch files so they work with the changes to the launch_ros API.

Perhaps a new branch `galactic-devel` could be created and made default?

Kind regards,

Russ