### PR TITLE
Use AND operation with match_command instead of OR operation

### DIFF
--- a/joy_teleop/config/joy_teleop_example.yaml
+++ b/joy_teleop/config/joy_teleop_example.yaml
@@ -72,6 +72,9 @@ teleop:
       -
         target: linear.y
         value: 0.0
+    # We don't want to have the walk buttons pressed
+    # to avoid publishing with different intentions
+    allow_multiple_commands: False
 
   hello:
     type: topic

--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -139,7 +139,10 @@ class JoyTeleop:
         for b in self.command_list[c]['buttons']:
             if b < 0 or len(buttons) <= b or buttons[b] != 1:
                 return False
-        return sum(buttons) == len(self.command_list[c]['buttons'])
+        if self.command_list[c]['allow_combinations']:
+            return sum(buttons) >= len(self.command_list[c]['buttons'])
+        else:
+            return sum(buttons) == len(self.command_list[c]['buttons'])
 
     def add_command(self, name, command):
         """Add a command to the command list"""
@@ -153,6 +156,7 @@ class JoyTeleop:
         elif command['type'] == 'service':
             if 'service_request' not in command:
                 command['service_request'] = {}
+        command['allow_combinations'] = command.get('allow_multiple_commands', True)
         self.command_list[name] = command
 
     def run_command(self, command, joy_state):

--- a/joy_teleop/scripts/joy_teleop.py
+++ b/joy_teleop/scripts/joy_teleop.py
@@ -139,7 +139,7 @@ class JoyTeleop:
         for b in self.command_list[c]['buttons']:
             if b < 0 or len(buttons) <= b or buttons[b] != 1:
                 return False
-        return sum(buttons) >= len(self.command_list[c]['buttons'])
+        return sum(buttons) == len(self.command_list[c]['buttons'])
 
     def add_command(self, name, command):
         """Add a command to the command list"""


### PR DESCRIPTION

Currently there is an issue in the joy_teleop that it matches the command even though there are more combination of buttons pressed along with the desired one. This PR intends to fix the issue.

For instance:
```
  # Switch to position controller
  switch_to_position_control:
    type: service
    service_name: /controller_manager/switch_controller
    service_request:
      start_controllers: ["left_leg_controller", "right_leg_controller"]
    buttons: [0, 5, 7]
```

Current behaviour: If I press 0,1,4,5 and 7 button or if I press only 0,5 and 7 buttons it swiches to position control

Intended behaviour: It has to switch to postiion control only If I press 0,5 and 7, but not with other combinations
