### PR TITLE
Replace deprecated dash by underscore

### DIFF
--- a/joy_teleop/setup.cfg
+++ b/joy_teleop/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/joy_teleop
+script_dir=$base/lib/joy_teleop
 [install]
-install-scripts=$base/lib/joy_teleop
+install_scripts=$base/lib/joy_teleop

--- a/key_teleop/setup.cfg
+++ b/key_teleop/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/key_teleop
+script_dir=$base/lib/key_teleop
 [install]
-install-scripts=$base/lib/key_teleop
+install_scripts=$base/lib/key_teleop

--- a/mouse_teleop/setup.cfg
+++ b/mouse_teleop/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/mouse_teleop
+script_dir=$base/lib/mouse_teleop
 [install]
-install-scripts=$base/lib/mouse_teleop
+install_scripts=$base/lib/mouse_teleop


### PR DESCRIPTION
To fix the following compilation warnings:

```
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
```