### PR TITLE
Fix excessive cpu consumption

### DIFF
--- a/joy_teleop/joy_teleop/incrementer_server.py
+++ b/joy_teleop/joy_teleop/incrementer_server.py
@@ -40,14 +40,12 @@
 #   * Jeremie Deray (artivis)
 #   * Borong Yuan
 
-import time
 
 from control_msgs.msg import JointTrajectoryControllerState as JTCS
 import rclpy
+from rclpy.wait_for_message import wait_for_message
 from rclpy.action import ActionServer
-from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.duration import Duration
-from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from teleop_tools_msgs.action import Increment as TTIA
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
@@ -58,42 +56,28 @@ class IncrementerServer(Node):
     def __init__(self):
         super().__init__('incrementer_server', namespace='joint_trajectory_controller')
 
-        cb_group = ReentrantCallbackGroup()
-
-        self._has_new_message = False
-
         self._as = ActionServer(self, TTIA, 'increment',
-                                self._as_cb, callback_group=cb_group)
+                                self._as_cb)
 
         self._command_pub = self.create_publisher(
             JointTrajectory, 'joint_trajectory', 1)
 
-        self._state_sub = self.create_subscription(
-            JTCS, 'controller_state', self._state_cb, 1, callback_group=cb_group)
-
         self._goal = JointTrajectory()
-        self.get_logger().info('Connected to {}'.format(self.get_namespace()))
+        self.get_logger().info(f'Connected to {self.get_namespace()}')
 
     def _as_cb(self, goal):
         self.increment_by(goal.request.increment_by)
         goal.succeed()
         return TTIA.Result()
 
-    def _state_cb(self, state):
-        self._state = state
-        self._has_new_message = True
-
-    # TODO(artivis) change after
-    # https://github.com/ros2/rclcpp/issues/520
-    # has landed
-    def _wait_for_new_message(self):
-        self._has_new_message = False
-        while not self._has_new_message:
-            time.sleep(0.01)
-        return self._state
+    def _wait_for_state_message(self):
+        msg_ok = False
+        while not msg_ok:
+            msg_ok, state = wait_for_message(JTCS, self, 'controller_state')
+        return state
 
     def increment_by(self, increment):
-        state = self._wait_for_new_message()
+        state = self._wait_for_state_message()
         self._goal.joint_names = state.joint_names
         self._value = state.feedback.positions
         self._value = [x + y for x, y in zip(self._value, increment)]
@@ -109,11 +93,9 @@ def main():
     rclpy.init()
 
     node = IncrementerServer()
-    executor = MultiThreadedExecutor()
-    executor.add_node(node)
 
     try:
-        executor.spin()
+        rclpy.spin(node)
     except KeyboardInterrupt:
         pass
 

--- a/joy_teleop/joy_teleop/incrementer_server.py
+++ b/joy_teleop/joy_teleop/incrementer_server.py
@@ -43,10 +43,10 @@
 
 from control_msgs.msg import JointTrajectoryControllerState as JTCS
 import rclpy
-from rclpy.wait_for_message import wait_for_message
 from rclpy.action import ActionServer
 from rclpy.duration import Duration
 from rclpy.node import Node
+from rclpy.wait_for_message import wait_for_message
 from teleop_tools_msgs.action import Increment as TTIA
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 


### PR DESCRIPTION
This pull request Fixes issue <https://github.com/ros-teleop/teleop_tools/issues/91>

The issue is caused by the `self._state_cb` where is going at the same rate of the Controller Manager. 

To solve this, the subscriber is created and destroyed every time the action is called using `wait_for_message ` rlcpy function. 

Before the fix: 
![cpu_consumption](https://github.com/user-attachments/assets/c71ad17c-6fab-4722-8e6d-0d5ca62fcb72)

After the fix: 
![cpu_consumption_solved](https://github.com/user-attachments/assets/ae3b9b82-1356-47df-8355-799e45fdef57)

fixes <https://github.com/ros-teleop/teleop_tools/issues/91>
