### PR TITLE
Fix axis_mappings in the joy_teleop_example.yaml for TwistStamped type

### DIFF
--- a/joy_teleop/config/joy_teleop_example.yaml
+++ b/joy_teleop/config/joy_teleop_example.yaml
@@ -7,19 +7,19 @@ joy_teleop:
       topic_name: cmd_vel
       deadman_buttons: [4]
       axis_mappings:
-        linear-x:
+        twist-linear-x:
           axis: 1
           scale: 0.5
           offset: -0.03
-        angular-z:
+        twist-angular-z:
           axis: 0
           scale: 0.5
           offset: 0
-        linear-y:
+        twist-linear-y:
           axis: 2
           scale: 0.3
           offset: 0
-        linear-z:
+        twist-linear-z:
           button: 2
           scale: 3.0
         header-frame_id:


### PR DESCRIPTION
The `interface_type` in the `joy_teleop_example.yaml` was changed to `TwistStamped` from `Twist` in the past. 

However, if the parameters under `axis_mappings` left unchanged, this example config would not work.

 I didn't initially pay attention to the config file and got:
 ```bash
 ...
 [joy_teleop-8] AttributeError: 'TwistStamped' object has no attribute 'angular'
[ERROR] [joy_teleop-8]: process has died
 ...
 ```
 Then, changed the values like this;
 ```yaml
 /**/joy_teleop:
  ros__parameters:
    move:
      type: topic
      interface_type: geometry_msgs/msg/TwistStamped
      topic_name: input_joy/cmd_vel # will publish messages to this
      deadman_buttons: [3] # hold the Y button of F710 to control robot, for safety
      # deadman_axes_negative: [5] # wait for PR #94 to be merged and use this with RT trigger instead
      axis_mappings:
        twist-linear-x: # <----------  [ from linear-x ]
          axis: 1 # left stick for driving forward/backward
          scale: 1.0
          offset: 0
        twist-angular-z: # <---------  [ from angular-z ]
          axis: 3 # right stick for turning
          scale: 0.5
          offset: 0
        header-frame_id:
          value: 'base_link'
```

Now it works.